### PR TITLE
Clarify MAC address usage in machines documentation

### DIFF
--- a/docs/machine
+++ b/docs/machine
@@ -1,0 +1,1 @@
+Automaty používají svou MAC adresu z výroby v databázi, v tabulce machines jako PK. Toto je nejlepší způsob protože MAC je přiřazena z výroby a neměla by jít měnit, také se vyhne ostatním způsobům přiřazování ID které jsou náchylné k lidské chybě.


### PR DESCRIPTION
Updated documentation to explain the use of MAC addresses as primary keys in the machines table.